### PR TITLE
Tests and bugfixes for PayMcpClient

### DIFF
--- a/src/__tests__/payMcpClient.test.ts
+++ b/src/__tests__/payMcpClient.test.ts
@@ -1,83 +1,117 @@
 import { SqliteOAuthClientDb } from '../oauthClientDb';
-import { OAuthClient, OAuthAuthenticationRequiredError } from '../oauthClient';
-import { describe, it, expect } from 'vitest';
+import { OAuthAuthenticationRequiredError } from '../oauthClient';
+import { describe, it, expect, vi } from 'vitest';
 import fetchMock from 'fetch-mock';
 import { mockResourceServer, mockAuthorizationServer } from './testHelpers';
 import { PayMcpClient } from '../payMcpClient';
-import { OAuthClientDb, FetchLike } from '../types';
+import { OAuthClientDb, FetchLike, PaymentMaker } from '../types';
 
-function payMcpClient(fetchFn: FetchLike, db?: OAuthClientDb, isPublic: boolean = false, strict: boolean = true) {
+function payMcpClient(fetchFn: FetchLike, solanaPaymentMaker?: PaymentMaker, db?: OAuthClientDb, isPublic: boolean = false, strict: boolean = true) {
+  solanaPaymentMaker = solanaPaymentMaker ?? {
+    makePayment: vi.fn().mockResolvedValue('testPaymentId'),
+    signBySource: vi.fn().mockResolvedValue('testSignature')
+  };
   return new PayMcpClient(
     db ?? new SqliteOAuthClientDb(':memory:'),
     isPublic,
-    {},
+    {'solana': solanaPaymentMaker},
     fetchFn,
     strict
   );
 }
 describe('payMcpClient.fetch', () => {
-  it('should return response if request returns 200', async()=> {
-    expect.fail();
-  });
-
-  it('should return request on non-OAuth-challenge 401', async () => {
-    expect.fail();
-  });
-
   it('should bubble up OAuthAuthenticationRequiredError on OAuth-but-not-PayMcp challenge', async () => {
-    expect.fail();
+    const f = fetchMock.createInstance().getOnce('https://example.com/mcp', 401);
+    mockResourceServer(f, 'https://example.com', '/mcp', 'https://paymcp.com');
+    mockAuthorizationServer(f, 'https://paymcp.com');
+
+    const client = payMcpClient(f.fetchHandler);
+    await expect(client.fetch('https://example.com/mcp')).rejects.toThrow(OAuthAuthenticationRequiredError);
+  });
+
+  it('should throw an error if amount isnt specified', async () => {
+    const f = fetchMock.createInstance().getOnce('https://example.com/mcp', 401);
+    mockResourceServer(f, 'https://example.com', '/mcp', 'https://paymcp.com?payMcp=1&network=solana&destination=testDestination&currency=USDC');
+    mockAuthorizationServer(f, 'https://paymcp.com', '?payMcp=1&network=solana&destination=testDestination&currency=USDC');
+    const paymentMaker = {
+      makePayment: vi.fn().mockResolvedValue('testPaymentId'),
+      signBySource: vi.fn().mockResolvedValue('testSignature')
+    };
+    const client = payMcpClient(f.fetchHandler, paymentMaker);
+
+    await expect(client.fetch('https://example.com/mcp')).rejects.toThrow(/amount not provided/);
   });
 
   it('should make a payment and post it to the authorization server for PayMcp challenge', async () => {
-    expect.fail();
-  });
+    const f = fetchMock.createInstance()
+      // 401, then succeed
+      .getOnce('https://example.com/mcp', 401)
+      .getOnce('https://example.com/mcp', {data: 'data'});
+    mockResourceServer(f, 'https://example.com', '/mcp', 'https://paymcp.com?payMcp=1&network=solana&destination=testDestination&currency=USDC&amount=0.01');
+    mockAuthorizationServer(f, 'https://paymcp.com', '?payMcp=1&network=solana&destination=testDestination&currency=USDC&amount=0.01')
+      // Respond to /authorize call 
+      .get('begin:https://paymcp.com/authorize', (req) => {
+        return {
+          status: 301,
+          headers: {location: `paymcp://paymcp?code=testCode&state=${new URL(req.args[0] as any).searchParams.get('state')}`}
+        };
+      });
+    const paymentMaker = {
+      makePayment: vi.fn().mockResolvedValue('testPaymentId'),
+      signBySource: vi.fn().mockResolvedValue('testSignature')
+    };
+    const client = payMcpClient(f.fetchHandler, paymentMaker);
 
-  it('should do OAuth handleCallback if PayMcp authorization server response is successful', async () => {
-    expect.fail();
+    await client.fetch('https://example.com/mcp');
+    // Ensure we make a payment and sign it
+    expect(paymentMaker.makePayment).toHaveBeenCalled();
+    expect(paymentMaker.signBySource).toHaveBeenCalled();
+
+    // Ensure we call the authorization endpoint
+    const authCall = f.callHistory.lastCall('begin:https://paymcp.com/authorize');
+    expect(authCall).toBeDefined();
+
+    // Ensure there was an auth header with the payment id and signature
+    const authHeader = (authCall!.args[1] as any).headers['Authorization'];
+    expect(authHeader).toBeDefined();
+    expect(authHeader).toContain('Bearer ');
+    const encodedPayment = authHeader.split(' ')[1];
+    const decodedPayment = Buffer.from(encodedPayment, 'base64').toString('utf-8');
+    expect(decodedPayment).toBe('testPaymentId:testSignature');
   });
 
   it('should throw if PayMcp authorization server response is not successful', async () => {
-    expect.fail();
+    const f = fetchMock.createInstance()
+      // 401, then succeed
+      .getOnce('https://example.com/mcp', 401)
+      .getOnce('https://example.com/mcp', {data: 'data'});
+    mockResourceServer(f, 'https://example.com', '/mcp', 'https://paymcp.com?payMcp=1&network=solana&destination=testDestination&currency=USDC&amount=0.01');
+    mockAuthorizationServer(f, 'https://paymcp.com', '?payMcp=1&network=solana&destination=testDestination&currency=USDC&amount=0.01')
+      // Respond to /authorize call 
+      .get('begin:https://paymcp.com/authorize', 401, {});
+    const client = payMcpClient(f.fetchHandler);
+
+    await expect(client.fetch('https://example.com/mcp')).rejects.toThrow('Expected redirect response from authorization URL, got 401');
   });
 
-  it('should re-attempt the request if PayMcp authorization server response is successful', async () => {
-    expect.fail();
-  });
+  it('should throw if authorization server authorization endpoint returns an error', async () => {
+    // We can't save this - the authorization URL was constructed using the client_id, so 
+    // if the client registration is no longer valid, there's nothing we can do.
+    const f = fetchMock.createInstance().getOnce('https://example.com/mcp', 401);
+    mockResourceServer(f, 'https://example.com', '/mcp', 'https://paymcp.com?payMcp=1&network=solana&destination=testDestination&currency=USDC&amount=0.01');
+    mockAuthorizationServer(f, 'https://paymcp.com', '?payMcp=1&network=solana&destination=testDestination&currency=USDC&amount=0.01')
+      /// Respond to /authorize call 
+      .get('begin:https://paymcp.com/authorize', (req) => {
+        const state = new URL(req.args[0] as any).searchParams.get('state');
+        return {
+          status: 301,
+          // This is how the AS responds to a bad request, as per RFC 6749
+          // It just redirects back to the client without a code and with an error
+          headers: {location: `paymcp://paymcp?state=${state}&error=invalid_request`}
+        };
+      });
 
-  it('should re-register client if authorization server authorization endpoint complains about an invalid client_id', async () => {
-    const db = new SqliteOAuthClientDb(':memory:');
-    db.saveClientCredentials('https://example.com/mcp', {
-      clientId: 'old-client-id',
-      clientSecret: 'old-client-secret',
-      redirectUri: 'paymcp://paymcp'
-    });
-    const f = fetchMock.mockGlobal().getOnce('https://example.com/mcp', 401);
-    mockResourceServer(f, 'https://example.com', '/mcp');
-    mockAuthorizationServer(f, 'https://paymcp.com')
-      // Simulate bad credentials response from the the AS response
-      .get('https://paymcp.com/authorize', 400);
-
-    const client = payMcpClient(f.fetchHandler, db);
-    try {
-      await client.fetch('https://example.com/mcp');
-    }
-    catch (e: any) {
-      const err = e as OAuthAuthenticationRequiredError;
-      expect(err.message).toContain('OAuth authentication required');
-      const authUrl = err.authorizationUrl.toString();
-    }
-    await expect(client.fetch('https://example.com/mcp')).rejects.toThrow(OAuthAuthenticationRequiredError);
-    const registerCall = f.callHistory.lastCall('https://paymcp.com/register');
-    expect(registerCall).toBeDefined();
-    const clientCredentials = await db.getClientCredentials('https://example.com/mcp');
-    expect(clientCredentials?.clientId).not.toBe('old-client-id');
-    expect(clientCredentials?.clientSecret).not.toBe('old-client-secret');
-    expect.fail();
-  });
-
-
-
-  it('should re-register client if authorization server complains about an invalid redirect_uri', async () => {
-    expect.fail();
+    const client = payMcpClient(f.fetchHandler);
+    await expect(client.fetch('https://example.com/mcp')).rejects.toThrow('authorization response from the server is an error');
   });
 });

--- a/src/__tests__/solanaPaymentMaker.test.ts
+++ b/src/__tests__/solanaPaymentMaker.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect } from 'vitest';
+import { SolanaPaymentMaker } from '../solanaPaymentMaker';
+import { Keypair } from "@solana/web3.js";
+import bs58 from "bs58";
+import nacl from "tweetnacl";
+import naclUtil from "tweetnacl-util";
 
 describe('solanaPaymentMaker.signBySource', () => {
-  it('should correctly sign and encode the result', async () => {
-    expect.fail();
+  it('should sign a payment by the source', async () => {
+    // This test is mainly here to force someone to read this if they change the signing,
+    // because you'll also need to account for that on the server side
+    const keypair = Keypair.generate();
+    const paymentMaker = new SolanaPaymentMaker('https://example.com', bs58.encode(keypair.secretKey));
+    const paymentId = 'test-payment-id';
+    const requestId = 'test-request-id';
+
+    const messageBytes = naclUtil.decodeUTF8(requestId + paymentId);
+    const signature = nacl.sign.detached(messageBytes, keypair.secretKey);
+    const expected = Buffer.from(signature).toString('base64');
+
+    const res = await paymentMaker.signBySource(requestId, paymentId);
+    expect(res).toBe(expected);
   });
 });
-
-  

--- a/src/__tests__/solanaPaymentMaker.test.ts
+++ b/src/__tests__/solanaPaymentMaker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 describe('solanaPaymentMaker.signBySource', () => {
   it('should correctly sign and encode the result', async () => {

--- a/src/__tests__/testHelpers.ts
+++ b/src/__tests__/testHelpers.ts
@@ -1,31 +1,31 @@
 import { FetchMock } from 'fetch-mock';
 
-export function mockResourceServer(mock: FetchMock, baseUrl: string = 'https://example.com', resourcePath: string = '/mcp') {
+export function mockResourceServer(mock: FetchMock, baseUrl: string = 'https://example.com', resourcePath: string = '/mcp', authServerUrl: string = 'https://paymcp.com') {
   mock.route({
     name: `${baseUrl}/.well-known/oauth-protected-resource${resourcePath}`,
     url: `${baseUrl}/.well-known/oauth-protected-resource${resourcePath}`,
     response: {
       body: {
         resource: baseUrl + resourcePath,
-        authorization_servers: ['https://paymcp.com']
+        authorization_servers: [authServerUrl]
       }
     }
   });
   return mock;
 }
 
-export function mockAuthorizationServer(mock: FetchMock, baseUrl: string = 'https://paymcp.com') {
-  mock.get(`${baseUrl}/.well-known/oauth-authorization-server`, {
-    issuer: baseUrl,
-    authorization_endpoint: `${baseUrl}/authorize`,
-    registration_endpoint: `${baseUrl}/register`,
-    token_endpoint: `${baseUrl}/token`,
-    introspection_endpoint: `${baseUrl}/introspect`
+export function mockAuthorizationServer(mock: FetchMock, baseUrl: string = 'https://paymcp.com', querystring: string = '') {
+  mock.get(`${baseUrl}/.well-known/oauth-authorization-server${querystring}`, {
+    issuer: `${baseUrl}${querystring}`,
+    authorization_endpoint: `${baseUrl}/authorize${querystring}`,
+    registration_endpoint: `${baseUrl}/register${querystring}`,
+    token_endpoint: `${baseUrl}/token${querystring}`,
+    introspection_endpoint: `${baseUrl}/introspect${querystring}`
   });
   // Use the more verbose route method to name the route, so we can .modifyRoute it later
   mock.route({
-    name: `${baseUrl}/token`,
-    url: `${baseUrl}/token`,
+    name: `${baseUrl}/token${querystring}`,
+    url: `${baseUrl}/token${querystring}`,
     method: 'post',
     repeat: 1,
     response: {
@@ -36,8 +36,8 @@ export function mockAuthorizationServer(mock: FetchMock, baseUrl: string = 'http
     }
   });
   mock.route({
-    name: `${baseUrl}/register`,
-    url: `${baseUrl}/register`, 
+    name: `${baseUrl}/register${querystring}`,
+    url: `${baseUrl}/register${querystring}`, 
     method: 'post',
     response: {
       status: 201,
@@ -49,8 +49,8 @@ export function mockAuthorizationServer(mock: FetchMock, baseUrl: string = 'http
     }
   });
   mock.route({
-    name: `${baseUrl}/introspect`,
-    url: `${baseUrl}/introspect`,
+    name: `${baseUrl}/introspect${querystring}`,
+    url: `${baseUrl}/introspect${querystring}`,
     method: 'post',
     repeat: 1,
     response: {


### PR DESCRIPTION
Completes test suite for OAuth / PayMcp clients, and fixes several bugs discovered:
- The paymcp client would charge $0 if the `amount` parameter wasn't included in the auth server URL; now it will throw an error
- The auth header sent to PayMcp's `/authorize` endpoint now has the `paymentId:signature` correctly encoded as base64 - the `:` is no longer UTF-8 😬 

This is back-incompatible for the PayMcp server because the auth header encoding change. I have purposefully NOT created a new NPM version, because I'll land the server-side updates in NPM alongside these ones.