### PR TITLE
CLI Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.32",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
         "@solana/pay": "^0.2.5",
         "@solana/web3.js": "^1.98.1",
         "@types/express": "^5.0.0",
@@ -471,6 +472,28 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
+      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@noble/curves": {
       "version": "1.9.0",
@@ -1359,6 +1382,22 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1709,6 +1748,19 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -1716,6 +1768,20 @@
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -1994,6 +2060,27 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2055,6 +2142,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
     "node_modules/eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -2062,6 +2164,18 @@
       "engines": {
         "node": "> 0.1.90"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
     },
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
@@ -2361,6 +2475,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
@@ -2413,6 +2533,12 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -2757,6 +2883,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -2797,6 +2932,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2843,6 +2987,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -2921,6 +3074,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qrcode-generator": {
@@ -3206,6 +3368,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -3613,6 +3796,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/utf-8-validate": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
@@ -3836,6 +4028,21 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3878,6 +4085,24 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.42",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.42.tgz",
+      "integrity": "sha512-PcALTLskaucbeHc41tU/xfjfhcz8z0GdhhDcSgrCTmSazUuqnYqiXO63M0QUBVwpBlsLsNVn5qHSC5Dw3KZvaQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@longrun/paymcp-client",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@longrun/paymcp-client",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "better-sqlite3": "^11.10.0",
         "bignumber.js": "^9.3.0",
         "bs58": "^6.0.0",
+        "dotenv": "^16.5.0",
         "express": "^5.0.0",
         "node-mocks-http": "^1.17.2",
         "oauth4webapi": "^3.5.0",
@@ -1806,6 +1807,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "cli": "tsx src/scripts/cli.ts"
   },
   "dependencies": {
     "@solana/pay": "^0.2.5",
@@ -24,6 +25,7 @@
     "better-sqlite3": "^11.10.0",
     "bignumber.js": "^9.3.0",
     "bs58": "^6.0.0",
+    "dotenv": "^16.5.0",
     "express": "^5.0.0",
     "node-mocks-http": "^1.17.2",
     "oauth4webapi": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "cli": "tsx src/scripts/cli.ts"
+    "cli": "tsx src/scripts/cli.ts",
+    "cli:fetch": "tsx src/scripts/cli-fetch.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cli": "tsx src/scripts/cli.ts"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
     "@solana/pay": "^0.2.5",
     "@solana/web3.js": "^1.98.1",
     "@types/express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@longrun/paymcp-client",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "PayMcp Client",
   "license": "MIT",
   "types": "./dist/index.d.ts",

--- a/src/customHttpTransport.ts
+++ b/src/customHttpTransport.ts
@@ -1,0 +1,459 @@
+import { StreamableHTTPClientTransportOptions, StreamableHTTPError, StreamableHTTPReconnectionOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { FetchLike } from './types.js';
+import { isInitializedNotification, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema } from '@modelcontextprotocol/sdk/types.js';
+import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+//import { auth, AuthResult, UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { EventSourceParserStream } from "eventsource-parser/stream"; // Transivitive depdendency of @modelcontextprotocol/sdk
+
+// Adapted from https://github.com/modelcontextprotocol/typescript-sdk/blob/df0d9c4ffc773b6414ba84bef3f016cf97e8cdd4/src/client/streamableHttp.ts#L80
+// Add support for custom fetch, our OAuth plumbing
+// Remove support for MCP SDK OAuth
+
+// Default reconnection options for StreamableHTTP connections
+const DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS: StreamableHTTPReconnectionOptions = {
+  initialReconnectionDelay: 1000,
+  maxReconnectionDelay: 30000,
+  reconnectionDelayGrowFactor: 1.5,
+  maxRetries: 2,
+};
+
+/**
+ * Client transport for Streamable HTTP: this implements the MCP Streamable HTTP transport specification.
+ * It will connect to a server using HTTP POST for sending messages and HTTP GET with Server-Sent Events
+ * for receiving messages.
+ */
+export class CustomHTTPTransport implements Transport {
+  private _fetchFn: FetchLike;
+  private _abortController?: AbortController;
+  private _url: URL;
+  //private _resourceMetadataUrl?: URL;
+  private _requestInit?: RequestInit;
+  //private _authProvider?: OAuthClientProvider;
+  private _sessionId?: string;
+  private _reconnectionOptions: StreamableHTTPReconnectionOptions;
+
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  constructor(
+    fetchFn: FetchLike,
+    url: URL,
+    opts?: StreamableHTTPClientTransportOptions,
+  ) {
+    this._fetchFn = fetchFn;
+    this._url = url;
+    //this._resourceMetadataUrl = undefined;
+    this._requestInit = opts?.requestInit;
+    //this._authProvider = opts?.authProvider;
+    this._sessionId = opts?.sessionId;
+    this._reconnectionOptions = opts?.reconnectionOptions ?? DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS;
+    if (opts?.authProvider) {
+      throw new Error('Novellum customHTTPTransport does not support authProvider')
+    }
+  }
+
+  /*private async _authThenStart(): Promise<void> {
+    if (!this._authProvider) {
+      throw new UnauthorizedError("No auth provider");
+    }
+
+    let result: AuthResult;
+    try {
+      result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+    } catch (error) {
+      this.onerror?.(error as Error);
+      throw error;
+    }
+
+    if (result !== "AUTHORIZED") {
+      throw new UnauthorizedError();
+    }
+
+    return await this._startOrAuthSse({ resumptionToken: undefined });
+  }*/
+
+  private async _commonHeaders(): Promise<Headers> {
+    const headers: HeadersInit = {};
+    /*if (this._authProvider) {
+      const tokens = await this._authProvider.tokens();
+      if (tokens) {
+        headers["Authorization"] = `Bearer ${tokens.access_token}`;
+      }
+    }*/
+
+    if (this._sessionId) {
+      headers["mcp-session-id"] = this._sessionId;
+    }
+
+    return new Headers(
+      { ...headers, ...this._requestInit?.headers }
+    );
+  }
+
+
+  private async _startOrAuthSse(options: { resumptionToken?: string, onresumptiontoken?: (token: string) => void, replayMessageId?: string | number }): Promise<void> {
+    const { resumptionToken } = options;
+    try {
+      // Try to open an initial SSE stream with GET to listen for server messages
+      // This is optional according to the spec - server may not support it
+      const headers = await this._commonHeaders();
+      headers.set("Accept", "text/event-stream");
+
+      // Include Last-Event-ID header for resumable streams if provided
+      if (resumptionToken) {
+        headers.set("last-event-id", resumptionToken);
+      }
+
+      const response = await this._fetchFn(this._url.toString(), {
+        method: "GET",
+        headers,
+        signal: this._abortController?.signal,
+      });
+
+      if (!response.ok) {
+        /*if (response.status === 401 && this._authProvider) {
+          // Need to authenticate
+          return await this._authThenStart();
+        }*/
+
+        // 405 indicates that the server does not offer an SSE stream at GET endpoint
+        // This is an expected case that should not trigger an error
+        if (response.status === 405) {
+          return;
+        }
+
+        throw new StreamableHTTPError(
+          response.status,
+          `Failed to open SSE stream: ${response.statusText}`,
+        );
+      }
+
+      this._handleSseStream(response.body, options);
+    } catch (error) {
+      this.onerror?.(error as Error);
+      throw error;
+    }
+  }
+
+
+  /**
+   * Calculates the next reconnection delay using  backoff algorithm
+   *
+   * @param attempt Current reconnection attempt count for the specific stream
+   * @returns Time to wait in milliseconds before next reconnection attempt
+   */
+  private _getNextReconnectionDelay(attempt: number): number {
+    // Access default values directly, ensuring they're never undefined
+    const initialDelay = this._reconnectionOptions.initialReconnectionDelay;
+    const growFactor = this._reconnectionOptions.reconnectionDelayGrowFactor;
+    const maxDelay = this._reconnectionOptions.maxReconnectionDelay;
+
+    // Cap at maximum delay
+    return Math.min(initialDelay * Math.pow(growFactor, attempt), maxDelay);
+
+  }
+
+  /**
+   * Schedule a reconnection attempt with exponential backoff
+   *
+   * @param lastEventId The ID of the last received event for resumability
+   * @param attemptCount Current reconnection attempt count for this specific stream
+   */
+  private _scheduleReconnection(options: { resumptionToken?: string, onresumptiontoken?: (token: string) => void, replayMessageId?: string | number }, attemptCount = 0): void {
+    // Use provided options or default options
+    const maxRetries = this._reconnectionOptions.maxRetries;
+
+    // Check if we've exceeded maximum retry attempts
+    if (maxRetries > 0 && attemptCount >= maxRetries) {
+      this.onerror?.(new Error(`Maximum reconnection attempts (${maxRetries}) exceeded.`));
+      return;
+    }
+
+    // Calculate next delay based on current attempt count
+    const delay = this._getNextReconnectionDelay(attemptCount);
+
+    // Schedule the reconnection
+    setTimeout(() => {
+      // Use the last event ID to resume where we left off
+      this._startOrAuthSse(options).catch(error => {
+        this.onerror?.(new Error(`Failed to reconnect SSE stream: ${error instanceof Error ? error.message : String(error)}`));
+        // Schedule another attempt if this one failed, incrementing the attempt counter
+        this._scheduleReconnection(options, attemptCount + 1);
+      });
+    }, delay);
+  }
+
+  private _handleSseStream(stream: ReadableStream<Uint8Array> | null, options: { onresumptiontoken?: (token: string) => void, replayMessageId?: string | number }): void {
+    if (!stream) {
+      return;
+    }
+    const { onresumptiontoken, replayMessageId } = options;
+
+    let lastEventId: string | undefined;
+    const processStream = async () => {
+      // this is the closest we can get to trying to catch network errors
+      // if something happens reader will throw
+      try {
+        // Create a pipeline: binary stream -> text decoder -> SSE parser
+        const reader = stream
+          .pipeThrough(new TextDecoderStream())
+          .pipeThrough(new EventSourceParserStream())
+          .getReader();
+
+
+        while (true) {
+          const { value: event, done } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          // Update last event ID if provided
+          if (event.id) {
+            lastEventId = event.id;
+            onresumptiontoken?.(event.id);
+          }
+
+          if (!event.event || event.event === "message") {
+            try {
+              const message = JSONRPCMessageSchema.parse(JSON.parse(event.data));
+              if (replayMessageId !== undefined && isJSONRPCResponse(message)) {
+                message.id = replayMessageId;
+              }
+              this.onmessage?.(message);
+            } catch (error) {
+              this.onerror?.(error as Error);
+            }
+          }
+        }
+      } catch (error) {
+        // Handle stream errors - likely a network disconnect
+        this.onerror?.(new Error(`SSE stream disconnected: ${error}`));
+
+        // Attempt to reconnect if the stream disconnects unexpectedly and we aren't closing
+        if (this._abortController && !this._abortController.signal.aborted) {
+          // Use the exponential backoff reconnection strategy
+          if (lastEventId !== undefined) {
+            try {
+              this._scheduleReconnection({
+                resumptionToken: lastEventId,
+                onresumptiontoken,
+                replayMessageId
+              }, 0);
+            }
+            catch (error) {
+              this.onerror?.(new Error(`Failed to reconnect: ${error instanceof Error ? error.message : String(error)}`));
+
+            }
+          }
+        }
+      }
+    };
+    processStream();
+  }
+
+  async start() {
+    if (this._abortController) {
+      throw new Error(
+        "StreamableHTTPClientTransport already started! If using Client class, note that connect() calls start() automatically.",
+      );
+    }
+
+    this._abortController = new AbortController();
+  }
+
+  /**
+   * Call this method after the user has finished authorizing via their user agent and is redirected back to the MCP client application. This will exchange the authorization code for an access token, enabling the next connection attempt to successfully auth.
+   */
+  /*async finishAuth(authorizationCode: string): Promise<void> {
+    if (!this._authProvider) {
+      throw new UnauthorizedError("No auth provider");
+    }
+
+    const result = await auth(this._authProvider, { serverUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl });
+    if (result !== "AUTHORIZED") {
+      throw new UnauthorizedError("Failed to authorize");
+    }
+  }*/
+
+  async close(): Promise<void> {
+    // Abort any pending requests
+    this._abortController?.abort();
+
+    this.onclose?.();
+  }
+
+  async send(message: JSONRPCMessage | JSONRPCMessage[], options?: { resumptionToken?: string, onresumptiontoken?: (token: string) => void }): Promise<void> {
+    try {
+      const { resumptionToken, onresumptiontoken } = options || {};
+
+      if (resumptionToken) {
+        // If we have at last event ID, we need to reconnect the SSE stream
+        this._startOrAuthSse({ resumptionToken, replayMessageId: isJSONRPCRequest(message) ? message.id : undefined }).catch(err => this.onerror?.(err));
+        return;
+      }
+
+      const headers = await this._commonHeaders();
+      headers.set("content-type", "application/json");
+      headers.set("accept", "application/json, text/event-stream");
+
+      const init = {
+        ...this._requestInit,
+        method: "POST",
+        headers,
+        body: JSON.stringify(message),
+        signal: this._abortController?.signal,
+      };
+
+      const response = await this._fetchFn(this._url.toString(), init);
+
+      // Handle session ID received during initialization
+      const sessionId = response.headers.get("mcp-session-id");
+      if (sessionId) {
+        this._sessionId = sessionId;
+      }
+
+      if (!response.ok) {
+        /*if (response.status === 401 && this._authProvider) {
+
+          this._resourceMetadataUrl = extractResourceMetadataUrl(response);
+
+          const result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+          if (result !== "AUTHORIZED") {
+            throw new UnauthorizedError();
+          }
+
+          // Purposely _not_ awaited, so we don't call onerror twice
+          return this.send(message);
+        }*/
+
+        const text = await response.text().catch(() => null);
+        throw new Error(
+          `Error POSTing to endpoint (HTTP ${response.status}): ${text}`,
+        );
+      }
+
+      // If the response is 202 Accepted, there's no body to process
+      if (response.status === 202) {
+        // if the accepted notification is initialized, we start the SSE stream
+        // if it's supported by the server
+        if (isInitializedNotification(message)) {
+          // Start without a lastEventId since this is a fresh connection
+          this._startOrAuthSse({ resumptionToken: undefined }).catch(err => this.onerror?.(err));
+        }
+        return;
+      }
+
+      // Get original message(s) for detecting request IDs
+      const messages = Array.isArray(message) ? message : [message];
+
+      const hasRequests = messages.filter(msg => "method" in msg && "id" in msg && msg.id !== undefined).length > 0;
+
+      // Check the response type
+      const contentType = response.headers.get("content-type");
+
+      if (hasRequests) {
+        if (contentType?.includes("text/event-stream")) {
+          // Handle SSE stream responses for requests
+          // We use the same handler as standalone streams, which now supports
+          // reconnection with the last event ID
+          this._handleSseStream(response.body, { onresumptiontoken });
+        } else if (contentType?.includes("application/json")) {
+          // For non-streaming servers, we might get direct JSON responses
+          const data = await response.json();
+          const responseMessages = Array.isArray(data)
+            ? data.map(msg => JSONRPCMessageSchema.parse(msg))
+            : [JSONRPCMessageSchema.parse(data)];
+
+          for (const msg of responseMessages) {
+            this.onmessage?.(msg);
+          }
+        } else {
+          throw new StreamableHTTPError(
+            -1,
+            `Unexpected content type: ${contentType}`,
+          );
+        }
+      }
+    } catch (error) {
+      this.onerror?.(error as Error);
+      throw error;
+    }
+  }
+
+  get sessionId(): string | undefined {
+    return this._sessionId;
+  }
+
+  /**
+   * Terminates the current session by sending a DELETE request to the server.
+   *
+   * Clients that no longer need a particular session
+   * (e.g., because the user is leaving the client application) SHOULD send an
+   * HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header to explicitly
+   * terminate the session.
+   *
+   * The server MAY respond with HTTP 405 Method Not Allowed, indicating that
+   * the server does not allow clients to terminate sessions.
+   */
+  async terminateSession(): Promise<void> {
+    if (!this._sessionId) {
+      return; // No session to terminate
+    }
+
+    try {
+      const headers = await this._commonHeaders();
+
+      const init = {
+        ...this._requestInit,
+        method: "DELETE",
+        headers,
+        signal: this._abortController?.signal,
+      };
+
+      const response = await this._fetchFn(this._url.toString(), init);
+
+      // We specifically handle 405 as a valid response according to the spec,
+      // meaning the server does not support explicit session termination
+      if (!response.ok && response.status !== 405) {
+        throw new StreamableHTTPError(
+          response.status,
+          `Failed to terminate session: ${response.statusText}`
+        );
+      }
+
+      this._sessionId = undefined;
+    } catch (error) {
+      this.onerror?.(error as Error);
+      throw error;
+    }
+  }
+}
+
+
+export function extractResourceMetadataUrl(res: Response): URL | undefined {
+
+  const authenticateHeader = res.headers.get("WWW-Authenticate");
+  if (!authenticateHeader) {
+    return undefined;
+  }
+
+  const [type, scheme] = authenticateHeader.split(' ');
+  if (type.toLowerCase() !== 'bearer' || !scheme) {
+    console.log("Invalid WWW-Authenticate header format, expected 'Bearer'");
+    return undefined;
+  }
+  const regex = /resource_metadata="([^"]*)"/;
+  const match = regex.exec(authenticateHeader);
+
+  if (!match) {
+    return undefined;
+  }
+
+  try {
+    return new URL(match[1]);
+  } catch {
+    console.log("Invalid resource metadata url: ", match[1]);
+    return undefined;
+  }
+}

--- a/src/scripts/cli-fetch.ts
+++ b/src/scripts/cli-fetch.ts
@@ -1,6 +1,15 @@
 import { PayMcpClient, SolanaPaymentMaker, SqliteOAuthDb } from '../index';
 import 'dotenv/config';
 
+function validateEnv() {
+  const requiredVars = ['SOLANA_ENDPOINT', 'SOLANA_PRIVATE_KEY'];
+  const missing = requiredVars.filter(varName => !process.env[varName]);
+  
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}\nPlease set them in your .env file or environment.`);
+  }
+}
+
 // Parse command line arguments
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -37,11 +46,13 @@ async function main() {
   // Create a SQLite database instance
   const db = new SqliteOAuthDb(':memory:');
   
-  // Create a new OAuth client
-  const solana = new SolanaPaymentMaker(process.env.SOLANA_ENDPOINT!, process.env.SOLANA_PRIVATE_KEY!);
-  const client = new PayMcpClient("local", db, true, {"solana": solana});
-
   try {
+    validateEnv();
+    
+    // Create a new OAuth client
+    const solana = new SolanaPaymentMaker(process.env.SOLANA_ENDPOINT!, process.env.SOLANA_PRIVATE_KEY!);
+    const client = new PayMcpClient("local", db, true, {"solana": solana});
+
     // Make a request to a protected resource
     // This will automatically handle the OAuth flow if needed
     const data = await client.fetch(

--- a/src/scripts/cli.ts
+++ b/src/scripts/cli.ts
@@ -3,6 +3,15 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import 'dotenv/config';
 import { CustomHTTPTransport } from '../customHttpTransport';
 
+function validateEnv() {
+  const requiredVars = ['SOLANA_ENDPOINT', 'SOLANA_PRIVATE_KEY'];
+  const missing = requiredVars.filter(varName => !process.env[varName]);
+  
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}\nPlease set them in your .env file or environment.`);
+  }
+}
+
 function parseArgs() {
   const args = process.argv.slice(2);
   const url = args[0] || 'https://browser-use.corp.pr0xy.co';
@@ -37,11 +46,13 @@ async function main() {
   // Create a SQLite database instance
   const db = new SqliteOAuthDb(':memory:');
   
-  // Create a new OAuth client
-  const solana = new SolanaPaymentMaker(process.env.SOLANA_ENDPOINT!, process.env.SOLANA_PRIVATE_KEY!);
-  const client = new PayMcpClient("local", db, true, {"solana": solana});
-
   try {
+    validateEnv();
+    
+    // Create a new OAuth client
+    const solana = new SolanaPaymentMaker(process.env.SOLANA_ENDPOINT!, process.env.SOLANA_PRIVATE_KEY!);
+    const client = new PayMcpClient("local", db, true, {"solana": solana});
+
     const mcpClient = new Client({
       name: "paymcp-client cli",
       version: "0.0.1"

--- a/src/scripts/cli.ts
+++ b/src/scripts/cli.ts
@@ -1,0 +1,57 @@
+import { PayMcpClient, SolanaPaymentMaker, SqliteOAuthDb } from '../index';
+import 'dotenv/config';
+
+async function main() {
+  console.log('Starting PayMcpClient example...');
+  
+  // Create a SQLite database instance
+  const db = new SqliteOAuthDb(':memory:');
+  
+  // Create a new OAuth client
+  const solana = new SolanaPaymentMaker(process.env.SOLANA_ENDPOINT!, process.env.SOLANA_PRIVATE_KEY!);
+  const client = new PayMcpClient("local", db, true, {"solana": solana});
+
+  try {
+    // Make a request to a protected resource
+    // This will automatically handle the OAuth flow if needed
+    const data = await client.fetch(
+      'http://localhost:3001',
+      {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json, text/event-stream',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "tools/call",
+          "params": {
+            "arguments": {
+              //"executionId": "development-paymcp-example-localhost-80661f45-ccb9-49f7-bd64-3e5ff0de8d55|asdfasdf"
+            },
+            //"name": "topHackerNewsStoriesWorkflow-results"
+            "name": "checkBalance" // browser-use
+          }
+        })
+      }
+    );
+    
+    console.log('Response:', data);
+    console.log('Body:', await data.text());
+    console.log('\nPayMcpClient example completed successfully!');
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('Error during OAuth flow:', error.message);
+    } else {
+      console.error('Unknown error during OAuth flow:', error);
+    }
+  } finally {
+    // Close the database connection
+    await db.close();
+    process.exit(0);
+  }
+}
+
+// Run the example
+main().catch(console.error); 

--- a/src/scripts/cli.ts
+++ b/src/scripts/cli.ts
@@ -1,8 +1,39 @@
 import { PayMcpClient, SolanaPaymentMaker, SqliteOAuthDb } from '../index';
 import 'dotenv/config';
 
+// Parse command line arguments
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const url = args[0] || 'https://browser-use.corp.pr0xy.co';
+  const toolName = args[1] || 'checkBalance';
+  
+  // Parse named arguments
+  const namedArgs: Record<string, string> = {};
+  for (let i = 2; i < args.length; i++) {
+    const arg = args[i];
+    const [key, value] = arg.split('=');
+    if (key && value) {
+      namedArgs[key] = value;
+    }
+  }
+
+  return { url, toolName, namedArgs };
+}
+
 async function main() {
   console.log('Starting PayMcpClient example...');
+  console.log('\nUsage:');
+  console.log('Direct: ts-node src/scripts/cli.ts [url] [toolName] [arg1=value1] [arg2=value2]');
+  console.log('Via npm: npm run cli -- [url] [toolName] [arg1=value1] [arg2=value2]');
+  console.log('\nExample: npm run cli -- http://localhost:3001 checkBalance foo=bar\n');
+  console.log('--------------------------------');
+  
+  const { url, toolName, namedArgs } = parseArgs();
+  console.log(`Calling tool "${toolName}" at URL: ${url}`);
+  if (Object.keys(namedArgs).length > 0) {
+    console.log('With arguments:', namedArgs);
+  }
+  console.log('--------------------------------');
   
   // Create a SQLite database instance
   const db = new SqliteOAuthDb(':memory:');
@@ -15,7 +46,7 @@ async function main() {
     // Make a request to a protected resource
     // This will automatically handle the OAuth flow if needed
     const data = await client.fetch(
-      'http://localhost:3001',
+      url,
       {
         method: 'POST',
         headers: {
@@ -27,11 +58,8 @@ async function main() {
           "id": 1,
           "method": "tools/call",
           "params": {
-            "arguments": {
-              //"executionId": "development-paymcp-example-localhost-80661f45-ccb9-49f7-bd64-3e5ff0de8d55|asdfasdf"
-            },
-            //"name": "topHackerNewsStoriesWorkflow-results"
-            "name": "checkBalance" // browser-use
+            "arguments": namedArgs,
+            "name": toolName
           }
         })
       }


### PR DESCRIPTION
Adds scripts to run paymcp-client in CLI mode:
- `npm run cli https://browser-use.corp.pr0xy.co checkBalance foo=bar` - connects to the specified MCP server URL and calls the indicated tool with the supplied args. Defaults to the values here and empty args
- `npm run cli-fetch` - same as the above, but does a direct HTTP POST, instead of creating a MCP SDK Client and calling the tool through that.

This also moves `customHttpTransport` into this package from Longrun. 