### PR TITLE
Bugfix: Properly support {'tools/call': 0.01} as a price config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@longrun/paymcp-client",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@longrun/paymcp-client",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@longrun/paymcp-client",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "PayMcp Client",
   "license": "MIT",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The existing implementation wouldn't actually charge if you set the price config to `{'tools/call': 0.01}` (ie to try to apply the price to all tools). However, because auth would still generally be required for `tools/call`, you'd be forced to make a payment the first time you used the tool. It would just never get consumed, and thus you'd never be asked for another payment as long as you used the tool. 